### PR TITLE
Remove Archetypes support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Introdução
 Este pacote integra o VLibras News API, desenvolvido pelo `Laboratório de Aplicações de Video Digital - LAViD`_, um Tradutor de Português para Libras para Plone.
 
 
+
 Estado deste pacote
 ---------------------
 
@@ -30,6 +31,9 @@ O estado atual dos testes pode ser visto nas imagens a seguir:
 
 .. warning:: Neste momento utilizamos a versão 1.0 do plone.app.contenttypes.
              A versão 1.1a1 introduziu mudanças na maneira como o Plone trabalha com Eventos.
+
+Este pacote suporta somente tipos de conteúdo Dexterity.
+
 
 Instalação
 ------------

--- a/src/brasil/gov/vlibrasvideo/subscribers.zcml
+++ b/src/brasil/gov/vlibrasvideo/subscribers.zcml
@@ -2,27 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <!-- Archetypes -->
-  <subscriber
-      zcml:condition="installed Products.Archetypes"
-      for="Products.Archetypes.interfaces.IBaseObject
-           Products.CMFCore.interfaces.IActionSucceededEvent"
-      handler=".utils.post_news"
-      />
-  <subscriber
-      zcml:condition="installed Products.Archetypes"
-      for="Products.Archetypes.interfaces.IBaseObject
-           zope.lifecycleevent.IObjectModifiedEvent"
-      handler=".utils.repost_news"
-      />
-  <subscriber
-      zcml:condition="installed Products.Archetypes"
-      for="Products.Archetypes.interfaces.IBaseObject
-           zope.lifecycleevent.IObjectRemovedEvent"
-      handler=".utils.delete_video"
-      />
-
-  <!-- Dexterity -->
   <subscriber
       zcml:condition="installed plone.app.dexterity"
       for="plone.dexterity.interfaces.IDexterityContent


### PR DESCRIPTION
We had some problems with Archetypes events when create new content in some circumstances;

When the News Item is inserted at root folder there is no problem, but in `/news` we get this exception:

```
2016-07-06 09:13:50 ERROR brasil.gov.vlibrasvideo GET - http://localhost:8080/Plone/news/aggregator: 404 - NOT FOUND
2016-07-06 09:17:18 ERROR Products.ZCatalog A different document with value '8da16368e8f84f368ce0b1000899575a' already exists in the index.'
2016-07-06 09:17:18 ERROR Zope.SiteErrorLog 1467807438.650.727521409054 http://localhost:8080/Plone/news/portal_factory/News Item/news_item.2016-07-06.2324379088/atct_edit
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.FactoryTool, line 478, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 29, in _call
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 107, in __call__
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 107, in __call__
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 107, in __call__
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 105, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 127, in __call__
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 1, in content_edit
   - <FSControllerPythonScript at /Plone/content_edit used for /Plone/news/portal_factory/News Item/forca-nacional-assume-a-seguranca-das-instalacoes-olimpicas>
   - Line 1
  Module Products.CMFCore.FSPythonScript, line 127, in __call__
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 344, in _exec
  Module script, line 8, in content_edit_impl
   - <FSPythonScript at /Plone/content_edit_impl used for /Plone/news/portal_factory/News Item/forca-nacional-assume-a-seguranca-das-instalacoes-olimpicas>
   - Line 8
  Module Products.CMFPlone.FactoryTool, line 321, in doCreate
  Module Products.ATContentTypes.lib.constraintypes, line 284, in invokeFactory
  Module Products.CMFCore.TypesTool, line 833, in constructContent
  Module Products.CMFCore.TypesTool, line 311, in constructInstance
  Module Products.CMFCore.TypesTool, line 552, in _constructInstance
  Module Products.ATContentTypes.content.newsitem, line 4, in addATNewsItem
  Module Products.BTreeFolder2.BTreeFolder2, line 426, in _setObject
  Module plone.app.folder.base, line 43, in _checkId
  Module Products.BTreeFolder2.BTreeFolder2, line 421, in _checkId
BadRequest: The id "news_item.2016-07-06.2324379088" is invalid--it is already in use.
```
